### PR TITLE
Handling responses with 204 status code

### DIFF
--- a/pypermedia/siren.py
+++ b/pypermedia/siren.py
@@ -32,6 +32,9 @@ def _check_and_decode_response(response):
     if response.status_code > 299 or response.status_code < 200:
         raise UnexpectedStatusError(message='Received an unexpected status code of "{0}"! Unable to construct siren objects.'.format(response.status_code))
 
+    if response.status_code == 204:
+        return None
+
     response = response.text
     if not response:
         raise MalformedSirenError(message='Parameter "response" object had empty response content. Unable to construct siren objects.')

--- a/tests/unit/test_siren.py
+++ b/tests/unit/test_siren.py
@@ -40,6 +40,17 @@ class TestSirenBuilder(unittest2.TestCase):
         resp = mock.Mock(status_code=200, text='')
         self.assertRaises(MalformedSirenError, _check_and_decode_response, resp)
 
+    def test_check_and_decode_no_content(self):
+        """
+        Tests that no entity is created when
+        status code is 204.
+        """
+        resp = mock.Mock(status_code=204, text=None)
+        assert _check_and_decode_response(resp) is None
+
+        resp = mock.Mock(status_code=204, text='')
+        assert _check_and_decode_response(resp) is None
+
     def test_construct_link(self):
         builder = SirenBuilder()
         link = builder._construct_link(dict(rel=['rel'], href='whocares'))


### PR DESCRIPTION
Following the issue started by ashic (https://github.com/vertical-knowledge/pypermedia/issues/9) regardless responses that do not contain the body, I have also run into similar problem. Although his point of handling 201 and 202 codes with no body is not necessarily valid, a 204 code is commonly used as a response to DELETE operations. As 204 response explicitly prohibits a body, it causes the executed actions to fail with MalformedSirenError, which in my opinion is incorrect, as technically there is no entity to parse in a first place (similarly to 404). This pull request is a simple mod that makes actions that get 204 response succeed.